### PR TITLE
Generate dbt and GE YAML from governance file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,11 @@
-
 # schema-yaml-starter
 
-Simple tool that scans `./data`, infers column names & types using Polars (fallback to Pandas for Excel), and writes YAML schema(s) to `./out`.
+Utility to either:
 
-## Quickstart
+* scan `./data`, infer column names & types using Polars (fallback to Pandas for Excel), and write schema YAMLs
+* or read an authoritative `governance.yaml` and emit dbt/Great Expectations YAML for data-quality tests
+
+## Quickstart – infer schemas from data
 
 ```bash
 python -m venv .venv
@@ -14,10 +16,35 @@ python -m schema_yaml.cli --data ./data --out ./out
 # schema-yaml --data ./data --out ./out
 ```
 
-## Output
-- One YAML per table: `./out/<table>.schema.yaml`
-- One combined YAML: `./out/_all_schemas.yaml`
+### Output
+* One YAML per table: `./out/<table>.schema.yaml`
+* One combined YAML: `./out/_all_schemas.yaml`
 
-## Supported inputs
-- CSV, XLSX
-- (Parquet supported if your env has pyarrow/fastparquet)
+### Supported inputs
+* CSV, XLSX
+* (Parquet supported if your env has pyarrow/fastparquet)
+
+## Governance → dbt/GE emission
+
+Maintain validation rules in a neutral `governance.yaml`:
+
+```yaml
+dataset:
+  kind: source
+  domain: raw
+  name: customers
+columns:
+  - name: customer_id
+    rules:
+      not_null: true
+      unique: true
+```
+
+Generate dbt v2 YAML (sources/models) and Great Expectations suites:
+
+```bash
+python -m schema_yaml.cli --governance governance.yaml --emit dbt,ge --out ./out
+```
+
+This writes `out/dbt/` and `out/ge/` directories containing the respective YAML files.
+

--- a/src/schema_yaml/cli.py
+++ b/src/schema_yaml/cli.py
@@ -4,17 +4,28 @@ from __future__ import annotations
 import argparse
 from pathlib import Path
 from .inspector import inspect_folder, write_outputs, inspect_from_config
+from .governance import emit_from_governance
 
 def main():
-    parser = argparse.ArgumentParser(description="Infer schemas from data files and output YAML.")
+    parser = argparse.ArgumentParser(description="Infer schemas or emit dbt/GE YAML from governance.")
     parser.add_argument("--data", type=str, default="./data", help="Input folder with files")
     parser.add_argument("--config", type=str, default=None, help="YAML config that lists files to scan")
+    parser.add_argument("--governance", type=str, default=None, help="Governance YAML to emit from")
+    parser.add_argument("--emit", type=str, default="", help="Comma-separated outputs to emit (dbt,ge)")
     parser.add_argument("--out", type=str, default="./out", help="Output folder for YAML")
     args = parser.parse_args()
 
-    data_dir = Path(args.data)
     out_dir = Path(args.out)
 
+    if args.governance:
+        emit = [e.strip() for e in args.emit.split(",") if e.strip()]
+        if not emit:
+            raise SystemExit("--emit must specify outputs when --governance is used")
+        emit_from_governance(Path(args.governance), out_dir, emit)
+        print(f"Governance emitted: {', '.join(emit)} -> {out_dir}")
+        return
+
+    data_dir = Path(args.data)
     pairs = inspect_from_config(Path(args.config)) if args.config else inspect_folder(data_dir)
     write_outputs(pairs, out_dir)
 

--- a/src/schema_yaml/governance.py
+++ b/src/schema_yaml/governance.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import List, Dict, Any
+import yaml
+
+
+def _dbt_tests_from_rules(rules: Dict[str, Any]) -> List[Any]:
+    tests: List[Any] = []
+    if not rules:
+        return tests
+    if rules.get("not_null"):
+        tests.append("not_null")
+    if rules.get("unique"):
+        tests.append("unique")
+    if "accepted_range" in rules:
+        r = rules["accepted_range"] or {}
+        params: Dict[str, Any] = {}
+        if "min" in r:
+            params["min_value"] = r["min"]
+        if "max" in r:
+            params["max_value"] = r["max"]
+        tests.append({"dbt_expectations.expect_column_values_to_be_between": params})
+    if "regex" in rules:
+        tests.append({"dbt_expectations.expect_column_values_to_match_regex": {"regex": rules["regex"]}})
+    return tests
+
+
+def governance_to_dbt(doc: Dict[str, Any]) -> str:
+    ds = doc.get("dataset", {})
+    cols = doc.get("columns", [])
+    root_key = "sources" if ds.get("kind") == "source" else "models"
+    out: Dict[str, Any] = {"version": 2, root_key: []}
+
+    if root_key == "sources":
+        src: Dict[str, Any] = {
+            "name": ds.get("domain"),
+            "tables": [
+                {
+                    "name": ds.get("name"),
+                    "columns": [
+                        {
+                            "name": c.get("name"),
+                            "description": c.get("description", ""),
+                            "tests": _dbt_tests_from_rules(c.get("rules", {})),
+                        }
+                        for c in cols
+                    ],
+                }
+            ],
+        }
+        if ds.get("database"):
+            src["database"] = ds["database"]
+        if ds.get("schema"):
+            src["schema"] = ds["schema"]
+        out[root_key].append(src)
+    else:
+        model = {
+            "name": ds.get("name"),
+            "columns": [
+                {
+                    "name": c.get("name"),
+                    "description": c.get("description", ""),
+                    "tests": _dbt_tests_from_rules(c.get("rules", {})),
+                }
+                for c in cols
+            ],
+        }
+        out[root_key].append(model)
+
+    return yaml.safe_dump(out, sort_keys=False, allow_unicode=True)
+
+
+def governance_to_ge(doc: Dict[str, Any]) -> str:
+    ds = doc.get("dataset", {})
+    cols = doc.get("columns", [])
+    expectations: List[Dict[str, Any]] = []
+
+    for c in cols:
+        name = c.get("name")
+        rules = c.get("rules", {})
+        if rules.get("not_null"):
+            expectations.append({
+                "expectation_type": "expect_column_values_to_not_be_null",
+                "kwargs": {"column": name},
+            })
+        if rules.get("unique"):
+            expectations.append({
+                "expectation_type": "expect_column_values_to_be_unique",
+                "kwargs": {"column": name},
+            })
+        if "accepted_range" in rules:
+            r = rules["accepted_range"] or {}
+            kwargs = {"column": name}
+            if "min" in r:
+                kwargs["min_value"] = r["min"]
+            if "max" in r:
+                kwargs["max_value"] = r["max"]
+            expectations.append({
+                "expectation_type": "expect_column_values_to_be_between",
+                "kwargs": kwargs,
+            })
+        if "regex" in rules:
+            expectations.append({
+                "expectation_type": "expect_column_values_to_match_regex",
+                "kwargs": {"column": name, "regex": rules["regex"]},
+            })
+
+    suite = {
+        "expectation_suite_name": ds.get("name"),
+        "expectations": expectations,
+    }
+    return yaml.safe_dump(suite, sort_keys=False, allow_unicode=True)
+
+
+def emit_from_governance(path: Path, out_dir: Path, emit: List[str]) -> Path:
+    doc = yaml.safe_load(Path(path).read_text(encoding="utf-8"))
+    out_dir.mkdir(parents=True, exist_ok=True)
+    if "dbt" in emit:
+        dbt_dir = out_dir / "dbt"
+        dbt_dir.mkdir(parents=True, exist_ok=True)
+        fname = "sources.yml" if doc.get("dataset", {}).get("kind") == "source" else "schema.yml"
+        dbt_dir.joinpath(fname).write_text(governance_to_dbt(doc), encoding="utf-8")
+    if "ge" in emit:
+        ge_dir = out_dir / "ge"
+        ge_dir.mkdir(parents=True, exist_ok=True)
+        suite_name = f"{doc.get('dataset', {}).get('name')}_suite.yml"
+        ge_dir.joinpath(suite_name).write_text(governance_to_ge(doc), encoding="utf-8")
+    return out_dir
+

--- a/tests/test_governance.py
+++ b/tests/test_governance.py
@@ -1,0 +1,55 @@
+from pathlib import Path
+import yaml
+
+from schema_yaml.governance import emit_from_governance
+
+
+def sample_governance() -> str:
+    return yaml.safe_dump(
+        {
+            "version": 1,
+            "dataset": {"kind": "source", "domain": "raw", "name": "customers"},
+            "columns": [
+                {
+                    "name": "customer_id",
+                    "type": "integer",
+                    "description": "Unique customer id",
+                    "rules": {"not_null": True, "unique": True},
+                },
+                {
+                    "name": "age",
+                    "type": "integer",
+                    "rules": {"accepted_range": {"min": 0, "max": 120}},
+                },
+            ],
+        },
+        sort_keys=False,
+        allow_unicode=True,
+    )
+
+
+def test_emit_from_governance(tmp_path: Path):
+    gpath = tmp_path / "governance.yaml"
+    gpath.write_text(sample_governance(), encoding="utf-8")
+
+    out_dir = tmp_path / "out"
+    emit_from_governance(gpath, out_dir, ["dbt", "ge"])
+
+    dbt_file = out_dir / "dbt" / "sources.yml"
+    assert dbt_file.exists()
+    dbt_doc = yaml.safe_load(dbt_file.read_text(encoding="utf-8"))
+    cols = dbt_doc["sources"][0]["tables"][0]["columns"]
+    cid = next(c for c in cols if c["name"] == "customer_id")
+    assert "not_null" in cid["tests"] and "unique" in cid["tests"]
+    age = next(c for c in cols if c["name"] == "age")
+    assert {"dbt_expectations.expect_column_values_to_be_between": {"min_value": 0, "max_value": 120}} in age["tests"]
+
+    ge_file = out_dir / "ge" / "customers_suite.yml"
+    assert ge_file.exists()
+    ge_doc = yaml.safe_load(ge_file.read_text(encoding="utf-8"))
+    exp_types = {e["expectation_type"] for e in ge_doc["expectations"]}
+    assert "expect_column_values_to_not_be_null" in exp_types
+    assert "expect_column_values_to_be_unique" in exp_types
+    between = next(e for e in ge_doc["expectations"] if e["expectation_type"] == "expect_column_values_to_be_between")
+    assert between["kwargs"]["min_value"] == 0 and between["kwargs"]["max_value"] == 120
+


### PR DESCRIPTION
## Summary
- add governance module to translate neutral `governance.yaml` into dbt tests and Great Expectations suites
- extend CLI with `--governance` and `--emit` flags to write dbt/GE YAML
- provide tests for governance emission and make existing tests self-contained
- document governance-driven dbt/GE emission in README

## Testing
- `PYTHONPATH=src pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c81ad59dbc83299183231ff82e1cb6